### PR TITLE
Make _copy_dir for <= 3.7 create dst if needed

### DIFF
--- a/install/__init__.py
+++ b/install/__init__.py
@@ -84,6 +84,8 @@ if sys.version_info >= (3, 8):
 else:
 
     def _copy_dir(src, dst, ignore=[]):  # type: (str, str, List[str]) -> None
+        if not os.path.exists(dst):
+            os.makedirs(dst)
         from distutils.dir_util import copy_tree
         for node in os.listdir(src):
             if node in ignore:


### PR DESCRIPTION
This matches the behaviour of the implementation used on Python 3.8+.
